### PR TITLE
(WIP) maybeInput and testing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,9 +10,28 @@ import Diagrams.Backend.SVG
 import Diagrams.Prelude hiding (rad)
 import Web.Suavemente
 import Web.Suavemente.Diagrams
+import Web.Suavemente.Input
+import Text.Blaze (preEscapedString)
 
 main :: IO ()
-main = suavemente sendDiagram $ do
+main = do
+  putStrLn "Server 👍"
+  putStrLn "point a client to localhost:8080"
+  let t1 = textbox_ "value" "abc"
+  suavementely
+    [ ("test-maybe", SomeSuave (markupTest "A Suave (Maybe String)") $
+          maybeInput "show" True t1)
+    , ("test-text", SomeSuave (markupTest "Just a wrapped textbox") $
+          div' "wrap" "" t1)
+    , ("example", SomeSuave sendDiagram example)
+    ]
+
+markupTest :: (Show a) => String -> a -> Markup
+markupTest comment =
+  preEscapedString . (++ "</p><hr>") . ((comment ++ "<hr><p>") ++) . show
+
+example :: Suave (QDiagram B V2 Double Any)
+example = do
   sq  <- dropdown "Shape"
            [ ("Triangle", "0")
            , ("Square", "1")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,8 +19,8 @@ main = do
   putStrLn "point a client to localhost:8080"
   let t1 = textbox_ "value" "abc"
   suavementely
-    [ ("test-maybe", SomeSuave (markupTest "A Suave (Maybe String)") $
-          maybeInput "show" True t1)
+    [ ("test-maybe", SomeSuave (markupTest "A Suave (Bool,String)") $
+          toggleInput "show" True "vis" t1)
     , ("test-text", SomeSuave (markupTest "Just a wrapped textbox") $
           div' "wrap" "" t1)
     , ("example", SomeSuave sendDiagram example)

--- a/src/Web/Suavemente/Input.hs
+++ b/src/Web/Suavemente/Input.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE QuasiQuotes      #-}
 {-# OPTIONS_GHC -Wall #-}
@@ -214,19 +215,9 @@ div' cl st = markupF (\x ->
 display :: Bool -> String
 display b = "display:" ++ bool "none" "block" b
 
--- | apply a checkbox that turns a Suave a into a Suave (Maybe a)
-maybeInput :: String -> Bool -> Suave a -> Suave (Maybe a)
-maybeInput label start sa =
-  (\c a -> bool Nothing (Just a) c) <$>
-  checkboxShow label "wrap" start <*>
-  div' "wrap" (display start) sa
-
-{-
--- | not sure how to use ApplicativeDo here
--- No instance for (Monad Suave) arising from a do statement
-maybeInput2 :: String -> Bool -> Suave a -> Suave (Maybe a)
-maybeInput2 label start sa = do
-  a <- div' "wrap" (display start) sa
-  c <- checkboxShow label "wrap" start
-  pure (bool Nothing (Just a) c)
--}
+-- | A checkbox that toggles visibility of another input (Suave a)
+toggleInput :: String -> Bool -> String -> Suave a -> Suave (Bool, a)
+toggleInput label start cl sa = do
+  a <- div' cl (display start) sa
+  c <- checkboxShow label cl start
+  pure (c,a)


### PR DESCRIPTION
Trying to apply #4 suggestions:

You can't wrap table tags <td> and <tr> with a div, so there's some refactoring that needs doing if you wanted this type of thing in the library.

I couldn't work out how to write what I had in mind with ApplicativeDo but I got there with normal applicative style.  I'm just at a loss about how to refactor between the two.

I jumped down to a value-level solution just to simplify my ApplicativeDo confusions.

Whilst hacking away, It felt that the Markup bit of an Input could usefully be altered to:

```
data MarkupInput = MarkupInput { inputStyle :: Markup, inputScript :: Markup, inputHtml :: Markup }
```

or even

```
data Widget a = Widget { style :: a, script :: a, html :: a }
```

and then you could inject the css, js and html elements of an input in a neater spot then in the middle of the body.

Similarly, passing around all these Strings that are css styles, html tag wrapping, js code etc, and there should be easy benefits to start using blaze types (or whatever), especially when trying to modify a html element inside an input.  Maybe Text.Blaze is already usable and I didn't notice.




